### PR TITLE
fixed the main uxgl side-nav / added scrim

### DIFF
--- a/src/scss/_side-navigation.scss
+++ b/src/scss/_side-navigation.scss
@@ -1,4 +1,5 @@
-$sideNavWidth: 220px;
+$sideNavWidth: 235px;
+$sideNavBoxShadow: 3px 0 5px -4px #444;
 
 #mainContent {
 	display: block;
@@ -23,8 +24,14 @@ $sideNavWidth: 220px;
 }
 
 .side-navigation {
+	box-shadow: $sideNavBoxShadow;
+	background-color: #FFF;
+	height: 100%;
+	left: 0;
+	padding-left: 15px;
 	padding-top: 35px;
-	z-index: 1;
+	width: $sideNavWidth;
+	z-index: 11;
 
 	li {
 		> a {
@@ -82,6 +89,25 @@ $sideNavWidth: 220px;
 	.collapse {
 		clear: both;
 	}
+}
+
+/* Adds scrim to sidenav */
+
+.sidenav-scrim:before {
+	background-color: rgba(0,0,0,0.3);
+	bottom: 0;
+	display: block;
+	left: 0;
+	position: absolute;
+	right: 0;
+	top: 0;
+	z-index: 10;
+	transition: opacity ease-in-out 0.38s, visibility ease-in-out 0.38s;
+}
+
+.closed.sidenav-scrim:before {
+	visibility: hidden;
+	opacity: 0;
 }
 
 /* Styles for side navigation component page */
@@ -146,14 +172,19 @@ $sideNavWidth: 220px;
 
 @media (min-width: $grid-float-breakpoint) {
 	#wrapper {
-		> .sidenav-container.closed {
+		> .sidenav-container {
 			> .sidenav-menu-slider {
-				width: $sideNavWidth;
+				transform: translateX(0);
+				width: 235px;
 			}
 
 			> .sidenav-content {
 				padding-left: $sideNavWidth + 35;
 			}
+		}
+		> .sidenav-scrim:before {
+			visibility: hidden;
+			opacity: 0;
 		}
 	}
 }

--- a/src/scss/lr7-_styled-theme/_side-navigation.scss
+++ b/src/scss/lr7-_styled-theme/_side-navigation.scss
@@ -22,6 +22,8 @@
 .sidenav-container.closed {
 	> .sidenav-menu-slider {
 		overflow: hidden;
+		transform: translateX(-100%);
+		@include transition(transform 0.3s ease-in-out, width 0s 0.4s);
 		width: 0;
 	}
 
@@ -60,14 +62,14 @@
 
 .sidenav-transition {
 	.sidenav-content {
-		@include transition(all 0.5s ease);
+		@include transition(all 0.3s ease-in-out);
 	}
 
 	.sidenav-menu-slider {
 		overflow: hidden;
 
-		&,.sidenav-menu {
-			@include transition(all 0.5s ease);
+		&, .sidenav-menu {
+			@include transition(transform 0.3s ease-in-out, width 0s);
 		}
 	}
 }

--- a/templates/includes/header.ejs
+++ b/templates/includes/header.ejs
@@ -40,5 +40,5 @@
 			</div>
 		</header>
 
-		<section class="closed container sidenav-container">
+		<section class="closed container sidenav-container sidenav-scrim">
 			<% include navigation %>


### PR DESCRIPTION
Hey @pat270,

I fixed the uxgl sidenav since it was breaking (floating text over content/if you left the sidebar open on mobile and resized the screen past the breakpoint the sidenav would cover content).

Also added a scrim and switched the width transition to a translateX(-100%).

Thanks!