### PR TITLE
Header margin adjusted to portal

### DIFF
--- a/src/scss/atlas-theme/_toolbars.scss
+++ b/src/scss/atlas-theme/_toolbars.scss
@@ -6,8 +6,8 @@
 
 	@media screen and (min-width: $grid-float-breakpoint) {
 		font-size: 19px;
-		padding-left: 24px;
-		padding-right: 24px;
+		padding-left: 0;
+		padding-right: 0;
 	}
 
 	.header-toolbar-title {

--- a/src/scss/lexicon-base/_grid.scss
+++ b/src/scss/lexicon-base/_grid.scss
@@ -8,7 +8,6 @@
 	padding-right: $grid-gutter-width / 2;
 }
 
-.header-toolbar,
 .management-bar,
 .navbar {
 	> .container-fluid-1280 {


### PR DESCRIPTION
Hey Patrick,

I'm not sure if this one is the best solution but we have problems to align header in portal because of this padding which is pushing header content when de screen is less than 1280px:

![image](https://cloud.githubusercontent.com/assets/7963804/11798476/5f0c6930-a2cb-11e5-9239-1f77acb04d40.png)

So I have changed these lines and tested in lexicon and portal:

![image](https://cloud.githubusercontent.com/assets/7963804/11798467/4a5d8028-a2cb-11e5-9674-c8ad002e625b.png)



