### PR TITLE
Update alerts component in lexicon-base

### DIFF
--- a/src/scss/lexicon-base/_alerts.scss
+++ b/src/scss/lexicon-base/_alerts.scss
@@ -3,7 +3,7 @@
 .alert-notification {
 	width: 100%;
 
-	@media screen and (min-width: $grid-float-breakpoint) {
+	@include media-breakpoint-up(md) {
 		max-width: $alert-notification-max-width;
 	}
 }

--- a/src/scss/lexicon-base/_lexicon.scss
+++ b/src/scss/lexicon-base/_lexicon.scss
@@ -1,4 +1,4 @@
-// @import "alerts";
+@import "alerts";
 // @import "aspect-ratio";
 // @import "badges";
 // @import "breadcrumbs";

--- a/src/scss/lexicon-base/_variables.scss
+++ b/src/scss/lexicon-base/_variables.scss
@@ -1,4 +1,4 @@
-// @import "variables/alerts";
+@import "variables/alerts";
 // @import "variables/breadcrumbs";
 // @import "variables/buttons";
 // @import "variables/cards";


### PR DESCRIPTION
- Updated the _alerts.scss because `$grid-float-breakpoint` is not a valid variable in v4.