### PR TITLE
Update forms component in lexicon-base

### DIFF
--- a/src/content/form_elements.html
+++ b/src/content/form_elements.html
@@ -27,7 +27,7 @@ section: Components
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse0"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse0"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse0">
 	<pre><code class="html">```<div class="form-group">
@@ -132,7 +132,7 @@ Checkboxes unable to be styled in IE with this method. -->
 </div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse3"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse3"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse3">
   <pre><code class="html">```<div class="checkbox">
@@ -179,7 +179,7 @@ Checkboxes unable to be styled in IE with this method. -->
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse4"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse4"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse4">
 	<pre><code class="html">```<div class="form-group">
@@ -221,7 +221,7 @@ Checkboxes unable to be styled in IE with this method. -->
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse5"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse5"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse5">
 	<pre><code class="html">```<div class="form-group">
@@ -282,7 +282,7 @@ Checkboxes unable to be styled in IE with this method. -->
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse6"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse6"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse6">
 	<pre><code class="html">```<div class="form-group">
@@ -346,7 +346,7 @@ Checkboxes unable to be styled in IE with this method. -->
 		</form>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse7"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse7"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse7">
 	<pre><code class="html">```<form>
@@ -402,7 +402,7 @@ Checkboxes unable to be styled in IE with this method. -->
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse8"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse8"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse8">
 	<pre><code class="html">```<div class="form-group">
@@ -425,7 +425,7 @@ Checkboxes unable to be styled in IE with this method. -->
 
 		<div class="form-group">
 			<label>Small text input</label>
-			<input class="form-control input-sm" placeholder="Placeholder" type="text">
+			<input class="form-control form-control-sm" placeholder="Placeholder" type="text">
 		</div>
 
 		<div class="form-group">
@@ -435,16 +435,16 @@ Checkboxes unable to be styled in IE with this method. -->
 
 		<div class="form-group">
 			<label>Large text input</label>
-			<input class="form-control input-lg" placeholder="Placeholder" type="text">
+			<input class="form-control form-control-lg" placeholder="Placeholder" type="text">
 		</div>
 
 <div class="uxgl-toggle-code">
-	<a class="btn btn-warning btn-xs" data-toggle="collapse" href="#codeCollapse9"><span class="icon-caret-down"></span></a>
+	<a class="btn btn-warning btn-sm" data-toggle="collapse" href="#codeCollapse9"><span class="icon-caret-down"></span></a>
 </div>
 <div class="collapse" id="codeCollapse9">
 	<pre><code class="html">```<div class="form-group">
     <label>Small text input</label>
-    <input class="form-control input-sm" placeholder="Placeholder" type="text">
+    <input class="form-control form-control-sm" placeholder="Placeholder" type="text">
 </div>
 
 <div class="form-group">
@@ -454,7 +454,7 @@ Checkboxes unable to be styled in IE with this method. -->
 
 <div class="form-group">
     <label>Large text input</label>
-    <input class="form-control input-lg" placeholder="Placeholder" type="text">
+    <input class="form-control form-control-lg" placeholder="Placeholder" type="text">
 </div>```</code></pre>
 </div>
 

--- a/src/scss/lexicon-base/_forms.scss
+++ b/src/scss/lexicon-base/_forms.scss
@@ -1,5 +1,0 @@
-@media screen and (max-width: $grid-float-breakpoint) {
-	.form-control {
-		font-size: 16px;
-	}
-}


### PR DESCRIPTION
- Removed `btn-xs` because the class was removed in v4 (see [Documentation](http://v4-alpha.getbootstrap.com/migration/#buttons))
- Renamed `input-lg` and `input-sm` to `form-control-lg` and `form-control-sm`, respectively. (see [Documentation](http://v4-alpha.getbootstrap.com/migration/#forms))
- Updated _forms.scss because `$grid-float-breakpoint` is not a valid variable in v4.