### PR TITLE
LPS-69305 Add += 0 to force minifier to not remove line as dead code

### DIFF
--- a/src/js/bootstrap/carousel.js
+++ b/src/js/bootstrap/carousel.js
@@ -144,7 +144,7 @@
     var slidEvent = $.Event('slid.bs.carousel', { relatedTarget: relatedTarget, direction: direction }) // yes, "slid"
     if ($.support.transition && this.$element.hasClass('slide')) {
       $next.addClass(type)
-      $next[0].offsetWidth // force reflow
+      $next[0].offsetWidth += 0 // force reflow
       $active.addClass(direction)
       $next.addClass(direction)
       $active


### PR DESCRIPTION
Just to explain this further, because the line I changed before was just a variable with no "logic" our JS minifiers recognized it as dead code and remove it, causing slides to not transition properly.  To that end, I added the += 0 to make the minifier believe that line is actually code and shouldn't be removed.